### PR TITLE
Fix referrer param assignment

### DIFF
--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -35,7 +35,7 @@ module TrackyDacks
             on /#{key}\.?(\w+)?/ do |format|
               roda_class.opts[:tracky_dacks][:runner].(
                 handler,
-                params.merge("referrer": referrer)
+                params.merge("referrer" => referrer)
               )
 
               if format == "png"


### PR DESCRIPTION
It was assigned as a symbol instead of a string, which caused it not being detected further down the track.